### PR TITLE
Added logic to handle ErrServerClosed for ListenAndServe.

### DIFF
--- a/internal/api/application.go
+++ b/internal/api/application.go
@@ -3,9 +3,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/metzben/tinystack/internal/api/url"
-	"github.com/metzben/tinystack/internal/config"
-	"github.com/rs/zerolog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -13,6 +10,10 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/metzben/tinystack/internal/api/url"
+	"github.com/metzben/tinystack/internal/config"
+	"github.com/rs/zerolog"
 )
 
 type Application struct {
@@ -82,8 +83,7 @@ func (app *Application) Serve() error {
 	}()
 
 	app.Logger.Info().Msgf("starting prod server on port: %+v", app.Configuration.Port)
-	prodServerErr := srvr.ListenAndServe()
-	if prodServerErr != nil {
+	if prodServerErr := srvr.ListenAndServe(); prodServerErr != nil && prodServerErr != http.ErrServerClosed {
 		return prodServerErr
 	}
 


### PR DESCRIPTION
**Issue:** the server shutdown is unblocking the ListenAndServe and returning an error in the Serve func.

**Evidence:**
The output shows an error is returned from our application (no good). 
![image](https://github.com/user-attachments/assets/694d875d-5483-4c4e-aa2f-c49b052b3b83)

My understanding of the cause is that when we get the os signal, we call srvr.Shutdown(ctx). That will unblock the ListenAndServe func with an error. The prodServerErr is returned to the main goroutine, and the application exits. This happens before nil is passed to shutDownErrChan. 
![image](https://github.com/user-attachments/assets/4b07ab97-670d-4493-9f16-9f944472f66a)

I see the fix as checking if the prodServerErr = http.ErrServerClosed and not returning if it is (since we caused the ErrServerClosed). This now produces the graceful shutdown we want. 
![image](https://github.com/user-attachments/assets/b0422600-d1b7-42c2-991d-19a457b4f5d7)


